### PR TITLE
adds types for other fed employment section 8

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -327,6 +327,23 @@ export const PersonWhoKnowsYou = Type.Object({
   address: Type.Union([USAddress, NonUsAddress])
 })
 
+export const DisiplinaryAction = Type.Object({
+  type: Type.String(),
+  explanation: Type.String(),
+  date: Type.Object({
+      date: Type.String(),
+      estimated: Type.Boolean(),
+  }),
+  actionInitiator: FullName,
+})
+export const FederalEmploymentPeriod = Type.Object({
+  dateRange:DateRange,
+  disaplinaryAction: Type.Optional(DisiplinaryAction),
+})
+export const OtherFederalEmployment = Type.Object({
+  agency: Type.String(),
+  employmentPeriods: Type.Array(FederalEmploymentPeriod),
+})
 export const PVQSchema = Type.Object({
   version: Type.Number(),
   // Section 01
@@ -368,7 +385,7 @@ export const PVQSchema = Type.Object({
   // Section 07
   employment: Type.Object({}),
   // Section 08
-  otherFederalEmployment: Type.Object({}),
+  otherFederalEmployment: Type.Array(OtherFederalEmployment),
   // Section 09
   usMilitary: Type.Object({}),
   // Section 10


### PR DESCRIPTION
Put this together for the other federal employment. Includes a type for FederalEmploymentPeriod and DisiplinaryAction. I have left off items like hasFederalEmployment as it strikes me as more of a requirement of the front end. Figure this could be interpolated by the presence of the data. 